### PR TITLE
[#354] Add get all survey responses request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added scope to content attributes global requirements [#349](https://github.com/rokwire/app-flutter-plugin/issues/349).
 - Initial handling of super and recurring events [#351](https://github.com/rokwire/app-flutter-plugin/issues/351).
 - Added progress to SectionSlantHeader [#351](https://github.com/rokwire/app-flutter-plugin/issues/351).
+- Add get all survey responses request [#354](https://github.com/rokwire/app-flutter-plugin/issues/354).
 ### Fixed
 - Upgrade dependencies for Flutter v3.10 [#285](https://github.com/rokwire/app-flutter-plugin/issues/285)
 - Survey maximum score JSON encoding error [#294](https://github.com/rokwire/app-flutter-plugin/issues/294)

--- a/lib/service/surveys.dart
+++ b/lib/service/surveys.dart
@@ -463,7 +463,41 @@ class Surveys /* with Service */ {
     return null;
   }
 
-  Future<List<SurveyResponse>?> loadSurveyResponses(
+  Future<List<SurveyResponse>?> loadAllSurveyResponses(String surveyId, {DateTime? startDate, DateTime? endDate, int? limit, int? offset}) async {
+    if (enabled) {
+      Map<String, String> queryParams = {};
+      if (startDate != null) {
+        String? startDateFormatted = AppDateTime().dateTimeLocalToJson(
+            startDate);
+        queryParams['start_date'] = startDateFormatted!;
+      }
+      if (endDate != null) {
+        String? endDateFormatted = AppDateTime().dateTimeLocalToJson(endDate);
+        queryParams['end_date'] = endDateFormatted!;
+      }
+      if (limit != null) {
+        queryParams['limit'] = limit.toString();
+      }
+      if (offset != null) {
+        queryParams['offset'] = offset.toString();
+      }
+
+      String url = '${Config().surveysUrl}/surveys/$surveyId/responses';
+      if (queryParams.isNotEmpty) {
+        url = UrlUtils.addQueryParameters(url, queryParams);
+      }
+      Response? response = await Network().get(url, auth: Auth2());
+      int responseCode = response?.statusCode ?? -1;
+      String? responseBody = response?.body;
+      if (responseCode == 200) {
+        List<dynamic>? responseMap = JsonUtils.decodeList(responseBody);
+        return SurveyResponse.listFromJson(responseMap);
+      }
+    }
+    return null;
+  }
+
+  Future<List<SurveyResponse>?> loadUserSurveyResponses(
       {List<String>? surveyIDs, List<
           String>? surveyTypes, DateTime? startDate, DateTime? endDate, int? limit, int? offset}) async {
     if (enabled) {

--- a/lib/ui/widgets/survey.dart
+++ b/lib/ui/widgets/survey.dart
@@ -238,7 +238,7 @@ class _SurveyWidgetState extends State<SurveyWidget> {
     } else if (survey is SurveyDataResult) {
       surveyWidget = _buildResultSurveySection(survey);
     } else if (survey is SurveyQuestionText) {
-      surveyWidget = _buildTextSurveySection(survey);
+      surveyWidget = _buildTextSurveySection(survey, readOnly: !widget.inputEnabled);
     }
     // else if (survey is SurveyDataPage) {
     //   surveyWidget = _buildPageWidget(survey);


### PR DESCRIPTION
## Description
This PR adds `loadAllSurveyResponses` to the `Surveys` service, which allows event admins to load all responses for a follow up survey. It also fixes a bug in `SurveyWidget` where text fields were not being disabled when the widget had `inputEnabled = false`.

**Fixes #354**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Immediately
- [ ] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)

