### PR TITLE
Tuned services initialization, get rid of initServiceFallback [#408].

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integrate auth refactor [#379](https://github.com/rokwire/app-flutter-plugin/issues/379)
 - Use CCT for Android OIDC login [#404](https://github.com/rokwire/app-flutter-plugin/issues/404)
 - Improve services init on app startup [#408](https://github.com/rokwire/app-flutter-plugin/issues/408)
+- Improve services failure processing [#408](https://github.com/rokwire/app-flutter-plugin/issues/408)
 
 ### Added
 - Web app authentication support [#291](https://github.com/rokwire/app-flutter-plugin/issues/291)

--- a/lib/service/analytics.dart
+++ b/lib/service/analytics.dart
@@ -100,9 +100,17 @@ class Analytics with Service implements NotificationsListener {
   @override
   void createService() {
     NotificationService().subscribe(this, [
+      Service.notifyInitialized,
       Connectivity.notifyStatusChanged,
     ]);
+  }
 
+  @override
+  void destroyService() {
+    NotificationService().unsubscribe(this);
+    closeDatabase();
+    closeTimer();
+    super.destroyService();
   }
 
   @override
@@ -147,24 +155,14 @@ class Analytics with Service implements NotificationsListener {
     }
   }
 
-  @override
-  void destroyService() {
-    NotificationService().unsubscribe(this, Connectivity.notifyStatusChanged);
-    closeDatabase();
-    closeTimer();
-    super.destroyService();
-  }
-
-  @override
-  Set<Service> get serviceDependsOn {
-    return { Connectivity(), Config() };
-  }
-
   // NotificationsListener
 
   @override
   void onNotification(String name, dynamic param) {
-    if (name == Connectivity.notifyStatusChanged) {
+    if (name == Service.notifyInitialized) {
+      onServiceInitialized(param is Service ? param : null);
+    }
+    else if (name == Connectivity.notifyStatusChanged) {
       applyConnectivityStatus(param);
     }
   }
@@ -237,7 +235,7 @@ class Analytics with Service implements NotificationsListener {
   @protected
   void onTimer(_) {
     
-    if ((_database != null) && !_inTimer && (_connectionStatus != ConnectivityStatus.none)) {
+    if ((_database != null) && !_inTimer && (_connectionStatus != ConnectivityStatus.none) && StringUtils.isNotEmpty(Config().loggingUrl)) {
       _inTimer = true;
 
       int? deliveryTimeout = Config().analyticsDeliveryTimeout;
@@ -296,11 +294,12 @@ class Analytics with Service implements NotificationsListener {
 
   @protected
   Future<bool> sendPacket(String? packet) async {
-    if (packet != null) {
+    String? loggingUrl = Config().loggingUrl;
+    if ((loggingUrl != null) && (packet != null)) {
       try {
         //TMP: Temporarly use ConfugApiKeyNetworkAuth auth until logging service gets updated to acknowledge the new Core BB token.
         //TBD: Remove this when logging service gets updated.
-        final response = await Network().post(Config().loggingUrl, body: packet, headers: { "Accept": "application/json", "Content-type": "application/json" }, auth: Config() /* Auth2() */, sendAnalytics: false);
+        final response = await Network().post(loggingUrl, body: packet, headers: { "Accept": "application/json", "Content-type": "application/json" }, auth: Config() /* Auth2() */, sendAnalytics: false);
         return (response != null) && ((response.statusCode == 200) || (response.statusCode == 201));
       }
       catch (e) {
@@ -311,11 +310,25 @@ class Analytics with Service implements NotificationsListener {
     return false;
   }
 
+  // Services
+
+  @protected
+  Future<void> onServiceInitialized(Service? service) async {
+    if (isInitialized) {
+      if (service == Connectivity()) {
+        updateConnectivity();
+      }
+    }
+  }
+
   // Connectivity
 
   @protected
   void updateConnectivity() {
-    applyConnectivityStatus(Connectivity().status);
+    ConnectivityStatus? connectionStatus = Connectivity().status;
+    if (_connectionStatus != connectionStatus) {
+      applyConnectivityStatus(Connectivity().status);
+    }
   }
 
   @protected

--- a/lib/service/events.dart
+++ b/lib/service/events.dart
@@ -82,11 +82,6 @@ class Events with Service implements NotificationsListener {
     processCachedEventDetails();
   }
 
-  @override
-  Set<Service> get serviceDependsOn {
-    return { DeepLink() };
-  }
-
   // NotificationsListener
 
   @override

--- a/lib/service/events2.dart
+++ b/lib/service/events2.dart
@@ -60,11 +60,6 @@ class Events2 with Service implements NotificationsListener {
     processCachedEventDetails();
   }
 
-  @override
-  Set<Service> get serviceDependsOn {
-    return { DeepLink() };
-  }
-
   // NotificationsListener
 
   @override

--- a/lib/service/firebase_messaging.dart
+++ b/lib/service/firebase_messaging.dart
@@ -15,17 +15,13 @@
  */
  
 import 'dart:async';
-import 'dart:ui';
 import 'package:flutter/foundation.dart';
 // import 'package:firebase_messaging/firebase_messaging.dart' as firebase_messaging;
-import 'package:rokwire_plugin/service/app_lifecycle.dart';
-import 'package:rokwire_plugin/service/config.dart';
 import 'package:rokwire_plugin/service/inbox.dart';
 import 'package:rokwire_plugin/service/firebase_core.dart';
 import 'package:rokwire_plugin/service/log.dart';
 import 'package:rokwire_plugin/service/notification_service.dart';
 import 'package:rokwire_plugin/service/service.dart';
-import 'package:rokwire_plugin/service/storage.dart';
 import 'package:rokwire_plugin/utils/utils.dart';
 
 
@@ -93,7 +89,7 @@ class FirebaseMessaging with Service {
 
   @override
   Set<Service> get serviceDependsOn {
-    return { FirebaseCore(), Storage(), Config() };
+    return { FirebaseCore() };
   }
 
   Future<NotificationsAuthorizationStatus> get authorizationStatus async {

--- a/lib/service/geo_fence.dart
+++ b/lib/service/geo_fence.dart
@@ -88,7 +88,7 @@ class GeoFence with Service implements NotificationsListener, ContentItemCategor
 
   @override
   Set<Service> get serviceDependsOn {
-    return {Storage(), Content()};
+    return { Storage(), Content() };
   }
 
   // NotificationsListener

--- a/lib/service/groups.dart
+++ b/lib/service/groups.dart
@@ -155,7 +155,7 @@ class Groups with Service implements NotificationsListener {
 
   @override
   Set<Service> get serviceDependsOn {
-    return { DeepLink(), Config(), Auth2() };
+    return { Config(), Auth2() };
   }
 
   // NotificationsListener

--- a/lib/service/http_proxy.dart
+++ b/lib/service/http_proxy.dart
@@ -18,13 +18,12 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:native_flutter_proxy/native_proxy_reader.dart';
-import 'package:rokwire_plugin/service/notification_service.dart';
 import 'package:rokwire_plugin/service/service.dart';
 import 'package:rokwire_plugin/service/storage.dart';
 import 'package:rokwire_plugin/service/config.dart';
 import 'package:rokwire_plugin/utils/utils.dart';
 
-class HttpProxy extends Service implements NotificationsListener {
+class HttpProxy extends Service {
   
   // Singletone Factory
 
@@ -45,8 +44,6 @@ class HttpProxy extends Service implements NotificationsListener {
   @override
   void createService() {
     super.createService();
-
-    NotificationService().subscribe(this, [Config.notifyEnvironmentChanged]);
   }
 
   @override
@@ -59,19 +56,11 @@ class HttpProxy extends Service implements NotificationsListener {
   @override
   void destroyService() {
     super.destroyService();
-    NotificationService().unsubscribe(this);
   }
 
   @override
   Set<Service> get serviceDependsOn {
-    return {Storage(), Config()};
-  }
-
-  @override
-  void onNotification(String name, dynamic param){
-    if(name == Config.notifyEnvironmentChanged){
-      _handleChanged();
-    }
+    return { Storage(), Config() };
   }
 
   Future<void> applySystemProxy() async {

--- a/lib/service/service.dart
+++ b/lib/service/service.dart
@@ -88,7 +88,7 @@ class Services {
 
   Future<ServiceError?> init() async {
     ServiceError? error = await _ServicesInitializer(initService).process(_services);
-    _isInitialized = (error != null);
+    _isInitialized = (error == null);
     return error;
   }
 

--- a/lib/service/service.dart
+++ b/lib/service/service.dart
@@ -65,6 +65,8 @@ class Services {
   static set instance(Services? value) => _instance = value;
 
   List<Service>? _services;
+
+  Future<ServiceError?>? _initialzeFuture;
   bool? _isInitialized;
 
   void create(List<Service> services) {
@@ -87,9 +89,16 @@ class Services {
   }
 
   Future<ServiceError?> init() async {
-    ServiceError? error = await _ServicesInitializer(initService).process(_services);
-    _isInitialized = (error == null);
-    return error;
+    if (_initialzeFuture != null) {
+      return await _initialzeFuture;
+    }
+    else {
+      _initialzeFuture = _ServicesInitializer(initService).process(_services);
+      ServiceError? error = await _initialzeFuture;
+      _isInitialized = (error == null);
+      _initialzeFuture = null;
+      return error;
+    }
   }
 
   bool get isInitialized => (_isInitialized == true);

--- a/lib/service/storage.dart
+++ b/lib/service/storage.dart
@@ -279,12 +279,6 @@ class Storage with Service {
   bool? get encryptedMigratedToSecureStorage => getBoolWithName(encryptedMigratedToSecureStorageKey);
   set encryptedMigratedToSecureStorage(bool? value) => setBoolWithName(encryptedMigratedToSecureStorageKey, value);
 
-  // Config
-
-  String get configEnvKey => 'edu.illinois.rokwire.config_environment';
-  String? get configEnvironment => getStringWithName(configEnvKey);
-  set configEnvironment(String? value) => setStringWithName(configEnvKey, value);
-
   // Upgrade
 
   String get reportedUpgradeVersionsKey  => 'edu.illinois.rokwire.reported_upgrade_versions';


### PR DESCRIPTION
Hi @shurwit, this is the suggested rework for removing initServiceFallback API from Services.

In short:
- Services dependency graph is optimized towards minimum dependency;
- Service.notifyInitialized notification is introduced. It is used to perform some post initialization of other services that have loose dependency on the initialized service but can be initialized independently on it.
- Removed config environment switching from Debug panels because it never worked well and it was a mistake to create this at all.

If you notice some minor tweaks please fell free to fix them straightly. If you have some more fundamental comments or concerns please let me know for them.

This PR is tight to [#713](https://github.com/rokmetro/vogue-app/pull/713) PR in Vogue app.

Thanks.