### PR TITLE
Fix wrong theme applied on first app launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve service initialization efficiency [#692](https://github.com/rokwire/app-flutter-plugin/issues/692)
 
 ### Fixed
+- Wrong theme applied on first app launch until backgrounded [#699](https://github.com/rokwire/app-flutter-plugin/issues/699)
 - Improve exception handling for passkeys [#396](https://github.com/rokwire/app-flutter-plugin/issues/396)
 - Improve error handling and logging for OIDC login url launcher
 

--- a/lib/service/styles.dart
+++ b/lib/service/styles.dart
@@ -339,7 +339,7 @@ class Styles extends Service implements NotificationsListener{
   String? _getSelectedTheme() {
     String? selectedTheme = Storage().selectedTheme;
     if (selectedTheme == null) {
-      Storage().selectedTheme = AppThemes.system;
+      selectedTheme = Storage().selectedTheme = AppThemes.system;
     }
 
     if (selectedTheme == AppThemes.system) {


### PR DESCRIPTION
## Summary
Fixes the wrong theme being applied on the very first launch after a fresh install (e.g. light theme on a dark-mode device). Backgrounding and reopening the app previously 'fixed' it.

## Root cause
`Styles._getSelectedTheme()` persisted the `AppThemes.system` default to storage when no preference existed, but never updated the local `selectedTheme` variable. As a result the `system -> light/dark` resolution block was skipped on first launch and the method returned `null`, so `_applySelectedTheme()` fell back to the un-themed `'default'` theme.

On a later resume, `updateFromNet()` -> `build()` -> `_getSelectedTheme()` ran again with `Storage().selectedTheme` now persisted as `'system'`, resolving correctly and firing `notifyChanged` — which is why backgrounding appeared to fix it.

## Change
```dart
if (selectedTheme == null) {
  selectedTheme = Storage().selectedTheme = AppThemes.system;
}
```

## Testing
- Clear app data / fresh install with the device in dark mode, launch the app, confirm the dark theme is applied immediately with no background/foreground cycle.
- Repeat with the device in light mode.
- Regression: switch theme in settings (light/dark/system), relaunch, confirm the selection persists and applies on launch.

Resolves #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)